### PR TITLE
CLN:change issue event type to added_to_project

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -42,9 +42,9 @@ jobs:
           labels: bug
 
       - name: set backlog label
-        run: echo should set a backlog label
+        run: echo should set a backlog label for project issue
 
       - uses: actions-ecosystem/action-add-labels@v1
-        if: ${{ startsWith(github.event.comment.body, '/backlog') }}
+        if: github.event.added_to_project
         with:
           labels: backlog


### PR DESCRIPTION
# Pull request format

This is a PR format for PawCon project.

## What's changed

**description**

1. issue event type changed from comment.body to added_to_project 

reference: https://docs.github.com/en/developers/webhooks-and-events/events/issue-event-types#added_to_project

**Linked issue(optional)**: #

**Screenshot/Clips(optional)**

- content here

## Checklist

- [x] Follow this project's commit convention
- [x] Follow this project's branch strategy convention
- [x] Set label and milestone
